### PR TITLE
Update MANIFEST.in to include `static` and `templates` folders

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include flask_material_lite/static *
+recursive-include flask_material_lite/templates *.html


### PR DESCRIPTION
Hi Adam,

when installing the package using pip you do not get the templates and static folders with it.
This patch should fix it.

Best regards,
Horia
